### PR TITLE
Minor fixes for data files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM python:3
 WORKDIR /usr/src/app
 
 COPY requirements.txt /usr/src/app/requirements.txt
+RUN wget https://github.com/vhf/confusable_homoglyphs/raw/master/confusables.json
+RUN wget https://github.com/vhf/confusable_homoglyphs/raw/master/categories.json
 RUN pip install psycopg2
 RUN pip install uwsgi
 RUN pip install -r requirements.txt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,9 @@ services:
       - POSTGRES_USER=${POSTGRES_USER}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
       - POSTGRES_DB=${POSTGRES_DB}
+      - PGDATA=/var/lib/postgresql/data/pgdata
     volumes:
-      - ./storage/postgresql:/var/lib/postgresql
+      - ./storage/postgresql:/var/lib/postgresql/data
   app:
     image: modelreg/modelreg:latest
     hostname: modelreg


### PR DESCRIPTION
The python module confusable_homoglyphs needs it's data files, or else
it will download them from the web when imported (which breaks within
Docker).

Also, to put postgres data into a docker volume, we need to put data
into a subfolder of the volume.