### PR TITLE
Introduce email configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,9 +27,9 @@ POSTGRES_DB=modelreg
 
 # Email settings - see this link for more info:
 # https://docs.djangoproject.com/en/1.11/ref/settings/#std:setting-EMAIL_PORT
-EMAIL_HOST = smtp.example.com
-EMAIL_PORT = 587
-EMAIL_HOST_USER = modelreguser
-EMAIL_HOST_PASSWORD = very3c3t!
-EMAIL_USE_TLS = true
-EMAIL_USE_SSL = false
+EMAIL_HOST_PASSWORD=very3c3t!
+EMAIL_HOST=smtp.example.com
+EMAIL_HOST_USER=modelreguser
+EMAIL_PORT=587
+EMAIL_USE_SSL=false
+EMAIL_USE_TLS=true

--- a/modelreg/settings_docker.py
+++ b/modelreg/settings_docker.py
@@ -29,7 +29,6 @@ ALLOWED_HOSTS = os.getenv('ALLOWED_HOSTS', '*').split(',')
 
 
 
-
 _db_configs = {
     'sqlite3': {
         'ENGINE': 'django.db.backends.sqlite3',
@@ -84,10 +83,10 @@ if os.getenv('EMAIL_HOST', False):
     # which is only useful for testing / development and will NOT
     # send out email.
     EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
-    set_if_exists('EMAIL_HOST')
-    set_if_exists('EMAIL_PORT', int)
-    set_if_exists('EMAIL_HOST_USER')
-    set_if_exists('EMAIL_HOST_PASSWORD')
-    set_if_exists('EMAIL_USE_TLS', bool_from_str)
-    set_if_exists('EMAIL_USE_SSL', bool_from_str)
+    set_from_env('EMAIL_HOST')
+    set_from_env('EMAIL_PORT', int)
+    set_from_env('EMAIL_HOST_USER')
+    set_from_env('EMAIL_HOST_PASSWORD')
+    set_from_env('EMAIL_USE_TLS', bool_from_str)
+    set_from_env('EMAIL_USE_SSL', bool_from_str)
 


### PR DESCRIPTION
You can now enable sending email via SMTP by setting the Django's
EMAIL_* settings variables in the environment.