### PR TITLE
Get rid of system update view.

### DIFF
--- a/modelreg/templates/system_update.html
+++ b/modelreg/templates/system_update.html
@@ -1,7 +1,0 @@
-<html>
-    <head>
-    </head>
-    <body>
-        System update: OK
-    </body>
-</html>

--- a/modelreg/urls.py
+++ b/modelreg/urls.py
@@ -21,8 +21,6 @@ from django.conf import settings
 from . import views
 
 urlpatterns = [
-    url(r'^system/update/%s' % settings.UPDATE_KEY, views.system_update),
-
     url(r'^admin/',    admin.site.urls),
     url(r'^accounts/', include('registration.backends.hmac.urls')),
     url(r'^profile/qrcode.png',  views.profile_qrcode_img, name='profile_code'),

--- a/modelreg/views.py
+++ b/modelreg/views.py
@@ -176,25 +176,3 @@ def profile_qrcode_img(req):
 
     img.save(response, 'png')
     return response
-
-
-@csrf_exempt
-def system_update(req):
-    import uwsgi
-    import git
-    from django.core.management import call_command
-
-    # This does not work properly yet, so disabling the code for now
-    # if req.POST['ref'] != 'refs/heads/master':
-    #     response = HttpResponseBadRequest()
-    #     response.write("Not master branch, not updating")
-    #     return response
-
-
-    git_cmd = git.cmd.Git(settings.BASE_DIR)
-    git_cmd.pull()
-
-    call_command('migrate')
-
-    uwsgi.reload()
-    return render(req, 'system_update.html')


### PR DESCRIPTION
We're providing up-to-date docker images now, so this is not necessary
anymore.