### PR TITLE
Implement email notifications for cases

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,3 +33,6 @@ EMAIL_HOST_USER=modelreguser
 EMAIL_PORT=587
 EMAIL_USE_SSL=false
 EMAIL_USE_TLS=true
+
+SYSTEM_EMAIL=modelreg@example.com
+SYSTEM_OPERATOR=ModelReg Team

--- a/README.md
+++ b/README.md
@@ -162,6 +162,13 @@ you can change if you want:
     * `-e EMAIL_USE_SSL=true`
     * `-e EMAIL_USE_TLS=false`
 
+  * *System settings*: Set the following variables to configure the name
+    and email address of your application.
+
+    * `-e SYSTEM_EMAIL=system@example.com` - The email address that is used
+      as the sender of all notifications. Does not need to own a mailbox.
+    * `-e SYSTEM_OPERATOR="ModelReg Team"` - The name of your team. Is used
+      as the greetings line in emails
 
 ToDo
 ----

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,8 @@ services:
       - EMAIL_HOST_PASSWORD=${EMAIL_HOST_PASSWORD}
       - EMAIL_USE_SSL=${EMAIL_USE_SSL}
       - EMAIL_USE_TLS=${EMAIL_USE_TLS}
+      - SYSTEM_OPERATOR=${SYSTEM_OPERATOR}
+      - SYSTEM_EMAIL=${SYSTEM_EMAIL}
   nginx:
     links:
       - app

--- a/modelreg/communication.py
+++ b/modelreg/communication.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+
+"""Documentation about the module... may be multi-line"""
+
+from django.core.mail import send_mail
+from django.urls import reverse
+from django.template.loader import render_to_string
+from django.conf import settings
+
+def _uri(request, view, *args, **kwargs):
+    return request.build_absolute_uri(reverse(view, args=args, kwargs=kwargs))
+
+
+def new_case(request, msg):
+    """Notify both owner and finder about a found model
+
+    Pass in a request and a CaseMessage as parameters.
+    """
+    notify_owner (request, msg, 'found')
+    notify_finder(request, msg, 'found')
+
+def notify_owner(request, msg, tag='update'):
+    """Notify the owner of an update regarding the current case.
+
+    Pass in a request and a CaseMessage as parameters.
+    """
+    return _notify(
+        request,
+        msg,
+        msg.case.model_owner.email,
+        'notify_owner_%s' % tag)
+
+
+def notify_finder(request, msg, tag='update'):
+    """Notify the finder of an update regarding the current case.
+
+    Pass in a request and a CaseMessage as parameters.
+    """
+    return _notify(
+        request,
+        msg,
+        msg.case.reporter_email,
+        'notify_finder_%s' % tag)
+
+
+def _notify(request, msg, recipient, template_prefix='notify_owner'):
+
+    context = {
+        'case':    msg.case,
+        'message': msg.message,
+        'owner':   msg.case.model_owner,
+        'operator': settings.SYSTEM_OPERATOR,
+
+        'owner_link':  _uri(request, 'case_owner',  msg.case.pk),
+        'finder_link': _uri(request, 'case_finder', msg.case.identifier),
+    }
+
+    subject = render_to_string('modelreg/%s_subject.txt' % template_prefix,
+                               context)
+    # Force subject to a single line to avoid header-injection
+    # issues.
+    subject = ''.join(subject.splitlines())
+
+    message = render_to_string('modelreg/%s.txt' % template_prefix,
+                               context)
+
+    send_mail(
+        subject,
+        message,
+        settings.SYSTEM_EMAIL,
+        [recipient]
+    )

--- a/modelreg/settings.py
+++ b/modelreg/settings.py
@@ -132,4 +132,8 @@ EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
 LOGIN_REDIRECT_URL = 'profile'
 
+SYSTEM_EMAIL    = 'modelreg@example.com'
+SYSTEM_OPERATOR = 'ModelReg Team'
+
 STATIC_ROOT = os.path.join(BASE_DIR, 'static')
+

--- a/modelreg/settings_docker.py
+++ b/modelreg/settings_docker.py
@@ -90,3 +90,5 @@ if os.getenv('EMAIL_HOST', False):
     set_from_env('EMAIL_USE_TLS', bool_from_str)
     set_from_env('EMAIL_USE_SSL', bool_from_str)
 
+SYSTEM_EMAIL    = os.getenv('SYSTEM_EMAIL',    'modelreg@example.com')
+SYSTEM_OPERATOR = os.getenv('SYSTEM_OPERATOR', 'ModelReg Team')

--- a/modelreg/templates/modelreg/notify_finder_found.txt
+++ b/modelreg/templates/modelreg/notify_finder_found.txt
@@ -1,0 +1,14 @@
+{% load i18n %}
+{% blocktrans %}
+Hi there!
+
+You successfully opened up a case with {{operator}}. The owner of the model
+has been notified. We'll let you know when they reply.
+
+Open this link to view the case:
+{{finder_link}}
+Note that replies to this email will not be read, so use the link instead.
+
+
+Best, {{operator}}
+{% endblocktrans %}

--- a/modelreg/templates/modelreg/notify_finder_found_subject.txt
+++ b/modelreg/templates/modelreg/notify_finder_found_subject.txt
@@ -1,0 +1,1 @@
+Your message has been recorded

--- a/modelreg/templates/modelreg/notify_finder_update.txt
+++ b/modelreg/templates/modelreg/notify_finder_update.txt
@@ -1,0 +1,19 @@
+{% load i18n %}
+{% blocktrans %}
+Hi there!
+
+A while ago, you reported a lost model. The owner of the model just replied to
+your message:
+
+------------------------ 8< ----------------------
+{{message}}
+------------------------ >8 ----------------------
+
+
+Open this link to respond:
+{{finder_link}}
+Note that replies to this email will not be read, so use the link instead.
+
+Best, {{operator}}
+
+{% endblocktrans %}

--- a/modelreg/templates/modelreg/notify_finder_update_subject.txt
+++ b/modelreg/templates/modelreg/notify_finder_update_subject.txt
@@ -1,0 +1,1 @@
+Your message has been recorded

--- a/modelreg/templates/modelreg/notify_owner_found.txt
+++ b/modelreg/templates/modelreg/notify_owner_found.txt
@@ -1,0 +1,19 @@
+{% load i18n %}
+{% blocktrans %}
+Hi there!
+
+Your model has been found! The finder has left you a message. Click the link at
+the end of this message to respond.
+
+------------------------ 8< ----------------------
+{{message}}
+------------------------ >8 ----------------------
+
+
+Open this link to respond:
+{{owner_link}}
+Note that replies to this email will not be read, so use the link instead.
+
+Best, {{operator}}
+
+{% endblocktrans %}

--- a/modelreg/templates/modelreg/notify_owner_found_subject.txt
+++ b/modelreg/templates/modelreg/notify_owner_found_subject.txt
@@ -1,0 +1,1 @@
+Your model has been found!

--- a/modelreg/templates/modelreg/notify_owner_update.txt
+++ b/modelreg/templates/modelreg/notify_owner_update.txt
@@ -1,0 +1,19 @@
+{% load i18n %}
+{% blocktrans %}
+Hi there!
+
+The finder of your model has left you a new message. Click the link at
+the end of this message to respond.
+
+------------------------ 8< ----------------------
+{{message}}
+------------------------ >8 ----------------------
+
+
+Open this link to respond:
+{{owner_link}}
+Note that replies to this email will not be read, so use the link instead.
+
+Best, {{operator}}
+
+{% endblocktrans %}

--- a/modelreg/templates/modelreg/notify_owner_update_subject.txt
+++ b/modelreg/templates/modelreg/notify_owner_update_subject.txt
@@ -1,0 +1,4 @@
+{% load i18n %}
+{% blocktrans %}
+A new message from someone who found your model!
+{% endblocktrans %}

--- a/modelreg/views.py
+++ b/modelreg/views.py
@@ -13,6 +13,7 @@ import qrcode
 
 from . import models
 
+from . import communication
 
 def found_info(req):
     """Info for someone who found a model
@@ -57,6 +58,8 @@ def found(req, ident, auth):
 
             msg.save()
 
+            communication.new_case(req, msg)
+
         return redirect('case_finder', ident=case.identifier)
 
     return render(req, 'found.html', {'public_profile': code})
@@ -89,6 +92,8 @@ def case_finder(req, ident):
         msg.message = req.POST['message']
         msg.save()
 
+        communication.notify_owner(req, msg)
+
     return render(req, 'case_finder.html', case_info(case))
 
 
@@ -105,6 +110,8 @@ def case_owner(req, pk):
         msg.from_owner = True
         msg.message = req.POST['message']
         msg.save()
+
+        communication.notify_finder(req, msg)
 
     return render(req, 'case_owner.html', case_info(case))
 


### PR DESCRIPTION
This implements email notifications for every interaction with a case.
The owner and finder both will get an email when a new case is opened.
Then, when either party updates the case, the other party is notified as
well, giving them the chance to respond.