### PR TITLE
Enable user language detection from the browser

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 
 
-help:
+help:  ## Show help for the available Make targets
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort -k 1,1 | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
-update-translations:
-	./manage.py makemessages --keep-pot
-
+update-translations:  ## Rebuild translation files
+	@./manage.py makemessages --keep-pot
+	@./manage.py compilemessages

--- a/modelreg/settings.py
+++ b/modelreg/settings.py
@@ -45,6 +45,7 @@ INSTALLED_APPS = [
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.locale.LocaleMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
@@ -105,15 +106,13 @@ AUTH_PASSWORD_VALIDATORS = [
 
 # Internationalization
 # https://docs.djangoproject.com/en/1.11/topics/i18n/
-
-LANGUAGE_CODE = 'en-us'
-
+LANGUAGE_CODE = 'de'
+LOCALE_PATHS = [
+    os.path.join(BASE_DIR, 'locale')
+]
 TIME_ZONE = 'UTC'
-
 USE_I18N = True
-
 USE_L10N = True
-
 USE_TZ = True
 
 


### PR DESCRIPTION
Enable the Locale middleware, and tell Django where to find
the translations.

Also, extend the Makefile so the .mo files are built as well